### PR TITLE
Fix/tokens

### DIFF
--- a/backend_api/backend_api/settings.py
+++ b/backend_api/backend_api/settings.py
@@ -84,6 +84,7 @@ TEMPLATES = [
     },
 ]
 
+CORS_ALLOW_CREDENTIALS = True
 
 CORS_ALLOWED_ORIGINS = [
     'http://localhost:5173',
@@ -219,3 +220,8 @@ SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(hours=2),  # Access token діє 2 години
     'REFRESH_TOKEN_LIFETIME': timedelta(days=14), # Refresh token діє 14 днів
 }
+
+# Налаштування cookie
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = 'Strict'
+SESSION_COOKIE_SECURE = False  # У продакшні  True для HTTPS

--- a/backend_api/core/serializers.py
+++ b/backend_api/core/serializers.py
@@ -109,16 +109,12 @@ class RegisterSerializer(serializers.ModelSerializer):
         user.save()
         user.generate_verification_code()
 
-        # Генеруємо посилання для активації
-        uid = urlsafe_base64_encode(force_bytes(user.pk))
-        token = default_token_generator.make_token(user)
-        activation_link = f"http://localhost:8000/api/auth/activate/{uid}/{token}/"
+
 
         send_mail(
             'Підтвердження реєстрації',
             f'Вітаємо, {user.username}!\n\n'
-            f'Ваш код підтвердження: {user.verification_code} (дійсний 1 годину).\n'
-            f'Або перейдіть за посиланням для активації: {activation_link}\n',
+            f'Ваш код підтвердження: {user.verification_code} (дійсний 1 годину).\n',
             settings.DEFAULT_FROM_EMAIL,
             [user.email],
             fail_silently=False,
@@ -307,16 +303,11 @@ class ResendVerificationCodeSerializer(serializers.Serializer):
         user.verification_expires_at = timezone.now() + timedelta(minutes=30)
         user.save()
 
-        # Додаємо посилання для активації
-        uid = urlsafe_base64_encode(force_bytes(user.pk))
-        token = default_token_generator.make_token(user)
-        activation_link = f"http://localhost:8000/api/auth/activate/{uid}/{token}/"
 
         send_mail(
             'Новий код підтвердження',
-            f'Ваш новий код підтвердження: {user.verification_code}\n'
-            f'Або перейдіть за посиланням для активації: {activation_link}',
-            settings.DEFAULT_FROM_EMAIL,  # Використовуємо DEFAULT_FROM_EMAIL
+            f'Ваш новий код підтвердження: {user.verification_code} (дійсний 30 хвилин).',
+            settings.DEFAULT_FROM_EMAIL,
             [user.email],
             fail_silently=False,
         )

--- a/backend_api/core/urls.py
+++ b/backend_api/core/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 from . import views
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
-from .views import CartListView, ProductViewSet, ResendVerificationCodeView, ActivateEmailView
+from .views import CartListView, ProductViewSet, ResendVerificationCodeView
 
 
 urlpatterns = [
@@ -14,7 +14,6 @@ urlpatterns = [
     path('orders/<int:pk>/', views.OrderViewSet.as_view({'get': 'retrieve', 'put': 'update', 'patch': 'partial_update', 'delete': 'destroy'}), name='order-detail'),
     path('auth/register/', views.RegisterView.as_view(), name='register'),
     path('auth/verify-email/', views.VerifyEmailView.as_view(), name='verify-email'),
-    path('auth/activate/<str:uidb64>/<str:token>/', views.ActivateEmailView.as_view(), name='activate-email'),
     path('auth/resend-verification-code/', ResendVerificationCodeView.as_view(), name='resend-verification-code'),
     path('auth/login/', views.LoginView.as_view(), name='login'),
     path('auth/refresh/', TokenRefreshView.as_view(), name='token_refresh'),

--- a/backend_api/core/urls.py
+++ b/backend_api/core/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 from . import views
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
-from .views import CartListView, ProductViewSet, ResendVerificationCodeView
+from .views import CartListView, ProductViewSet, ResendVerificationCodeView, CustomTokenRefreshView
 
 
 urlpatterns = [
@@ -16,7 +16,7 @@ urlpatterns = [
     path('auth/verify-email/', views.VerifyEmailView.as_view(), name='verify-email'),
     path('auth/resend-verification-code/', ResendVerificationCodeView.as_view(), name='resend-verification-code'),
     path('auth/login/', views.LoginView.as_view(), name='login'),
-    path('auth/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('auth/refresh/', CustomTokenRefreshView.as_view(), name='token_refresh'),
     path('auth/password-reset/', views.PasswordResetRequestView.as_view(), name='password_reset'),
     path('auth/password-reset-confirm/<str:uidb64>/<str:token>/', views.PasswordResetConfirmView.as_view(),
          name='password_reset_confirm'),

--- a/backend_api/core/views.py
+++ b/backend_api/core/views.py
@@ -8,14 +8,14 @@ from rest_framework.views import APIView
 from rest_framework_simplejwt.tokens import RefreshToken
 from django_filters.rest_framework import DjangoFilterBackend
 from .filters import ProductFilter, OrderFilter, UserFilter, CartFilter, ReviewFilter, AuctionBidFilter, FavoriteFilter, CategoryFilter, PaymentFilter, ShippingFilter
-
 from django.contrib.auth import get_user_model
 from .permissions import HasGroupPermission
 from .models import Product, Order, Cart, Review, AuctionBid, Favorite, Category, Payment, Shipping
 from .serializers import (ProductSerializer, OrderSerializer, UserSerializer,
                           RegisterSerializer, PasswordResetRequestSerializer,
                           PasswordResetConfirmSerializer, VerifyEmailSerializer, LoginSerializer,
-                          CartSerializer, ResendVerificationCodeSerializer, OrderItem, CartRemoveSerializer, ReviewSerializer, AuctionBidSerializer, FavoriteSerializer, CategorySerializer, PaymentSerializer, ShippingSerializer, UserProfileSerializer)
+                          CartSerializer, ResendVerificationCodeSerializer, OrderItem, CartRemoveSerializer, ReviewSerializer, 
+                          AuctionBidSerializer, FavoriteSerializer, CategorySerializer, PaymentSerializer, ShippingSerializer, UserProfileSerializer)
 from django.utils.http import urlsafe_base64_decode
 from django.utils.encoding import force_str
 from django.contrib.auth.tokens import default_token_generator
@@ -192,22 +192,49 @@ class LoginView(generics.GenericAPIView):
 
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
-        if serializer.is_valid():
-            user = serializer.validated_data['user']
-            refresh = RefreshToken.for_user(user)
-            return Response({
-                'success': True,
-                'access': str(refresh.access_token),
-                'refresh': str(refresh)
-            }, status=status.HTTP_200_OK)
-        return Response({
-            'success': False,
-            'errors': serializer.errors
-        }, status=status.HTTP_400_BAD_REQUEST
+        serializer.is_valid(raise_exception=True)
+        user = serializer.validated_data['user']
+        refresh = RefreshToken.for_user(user)
+
+        # access token у тілі відповіді
+        response_data = {
+            'success': True,
+            'access': str(refresh.access_token),
+        }
+
+        response = Response(response_data, status=status.HTTP_200_OK)
+        response.set_cookie(
+            key='refresh_token',
+            value=str(refresh),
+            httponly=True,
+            secure=False,  # True у продакшені
+            samesite='Strict',
+            max_age=14 * 24 * 60 * 60,
         )
+        return response
 
 
-
+class CustomTokenRefreshView(APIView):
+    def post(self, request, *args, **kwargs):
+        refresh_token = request.COOKIES.get('refresh_token')
+        if not refresh_token:
+            return Response(
+                {"success": False, "errors": {"detail": "Refresh token not provided in cookies"}},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
+        try Newcastle United Football Club
+            refresh = RefreshToken(refresh_token)
+            access_token = str(refresh.access_token)
+            return Response(
+                {"success": True, "access": access_token},
+                status=status.HTTP_200_OK
+            )
+        except Exception as e:
+            return Response(
+                {"success": False, "errors": {"detail": str(e)}},
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
 
 class CartAddView(generics.GenericAPIView):

--- a/backend_api/core/views.py
+++ b/backend_api/core/views.py
@@ -372,33 +372,3 @@ class UserProfileView(generics.GenericAPIView):
         serializer = self.get_serializer(request.user)
         return Response({"success": True, "data": serializer.data})
 
-class ActivateEmailView(APIView):
-    def get(self, request, uidb64, token):
-        try:
-            uid = force_str(urlsafe_base64_decode(uidb64))
-            user = User.objects.get(pk=uid)
-        except (TypeError, ValueError, OverflowError, User.DoesNotExist):
-            return Response(
-                {"success": False, "errors": {"detail": "Недійсне посилання"}},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-
-        if default_token_generator.check_token(user, token):
-            if not user.is_verified:
-                user.is_verified = True
-                user.is_active = True
-                user.verification_code = None
-                user.verification_expires_at = None
-                user.save()
-                return Response(
-                    {"success": True, "message": "Обліковий запис активовано"},
-                    status=status.HTTP_200_OK
-                )
-            return Response(
-                {"success": True, "message": "Обліковий запис уже активовано"},
-                status=status.HTTP_200_OK
-            )
-        return Response(
-            {"success": False, "errors": {"detail": "Недійсний токен"}},
-            status=status.HTTP_400_BAD_REQUEST
-        )


### PR DESCRIPTION
- Оновлено `LoginView` для повернення тільки `access_token` у JSON-відповіді, а `refresh_token` встановлюється у HttpOnly cookie.
- Додано `CustomTokenRefreshView` для обробки оновлення токена через cookie замість тіла запиту.
- Оновлено `urls.py`, щоб використовувати `CustomTokenRefreshView` для `/auth/refresh/`.
- Виправлено помилку в `CustomTokenRefreshView` (некоректний рядок `try Newcastle United Football Club`).
